### PR TITLE
create product and price on Stripe when a new product is added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "devise", "~> 4.9"
+gem "dotenv-rails", groups: [:development, :test]
 gem "elasticsearch-model"
 gem "elasticsearch-rails"
 gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.3)
     elastic-transport (8.4.0)
       faraday (< 3)
@@ -403,6 +407,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise (~> 4.9)
+  dotenv-rails
   elasticsearch-model
   elasticsearch-rails
   error_highlight (>= 0.4.0)

--- a/app/models/java_programming_catalog_product_subscription.rb
+++ b/app/models/java_programming_catalog_product_subscription.rb
@@ -1,0 +1,2 @@
+class JavaProgrammingCatalogProductSubscription < CatalogProductSubscription
+end

--- a/app/models/javaprogramming_catalog_product_subscription.rb
+++ b/app/models/javaprogramming_catalog_product_subscription.rb
@@ -1,2 +1,0 @@
-class JavaprogrammingCatalogProductSubscription < CatalogProductSubscription
-end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,8 +3,10 @@ class Product < ApplicationRecord
   has_many :courses, dependent: :destroy
   has_many :assessments, dependent: :destroy
   belongs_to :product_creator, class_name: "User"
+  has_many :product_prices, dependent: :destroy
 
   after_create :create_catalog_entry_and_class
+  after_commit :sync_with_stripe, on: [ :create, :update ]
 
   private
 
@@ -23,5 +25,30 @@ class Product < ApplicationRecord
       end
     end
     load file_path
+  end
+
+  def sync_with_stripe
+    if stripe_product_id.blank?
+      product = Stripe::CreateStripeProductService.process!(product: self)
+      update_column(:stripe_product_id, product.id)
+      stripe_price = Stripe::CreateStripePriceService.process!(cost: cost, product: product)
+      product_prices.create!(
+        stripe_price_id: stripe_price.id,
+        price: stripe_price.unit_amount,
+        currency: stripe_price.currency,
+        active: true,
+        product_id: id
+      )
+    elsif saved_change_to_cost?
+      stripe_price = Stripe::CreateStripePriceService.process!(cost: cost, product: stripe_product_id)
+      product_prices.update_all(active: false)
+      product_prices.create!(
+        stripe_price_id: stripe_price.id,
+        price: stripe_price.unit_amount,
+        currency: stripe_price.currency,
+        active: true,
+        product_id: id
+      )
+    end
   end
 end

--- a/app/models/product_price.rb
+++ b/app/models/product_price.rb
@@ -1,0 +1,3 @@
+class ProductPrice < ApplicationRecord
+  belongs_to :product
+end

--- a/app/services/stripe/create_stripe_price_service.rb
+++ b/app/services/stripe/create_stripe_price_service.rb
@@ -1,0 +1,9 @@
+class Stripe::CreateStripePriceService
+  def self.process!(cost:, product:)
+    ::Stripe::Price.create(
+      unit_amount: (cost.to_f * 100).to_i,
+      currency: "usd",
+      product: product.is_a?(String) ? product : product.id
+    )
+  end
+end

--- a/app/services/stripe/create_stripe_product_service.rb
+++ b/app/services/stripe/create_stripe_product_service.rb
@@ -1,0 +1,8 @@
+class Stripe::CreateStripeProductService
+  def self.process!(product:)
+    ::Stripe::Product.create(
+      name: product.name,
+      description: product.description
+    )
+  end
+end

--- a/db/migrate/20250828080157_add_stripe_product_id_to_product.rb
+++ b/db/migrate/20250828080157_add_stripe_product_id_to_product.rb
@@ -1,0 +1,6 @@
+class AddStripeProductIdToProduct < ActiveRecord::Migration[7.2]
+  def change
+    add_column :products, :stripe_product_id, :string
+    add_index :products, :stripe_product_id, unique: true
+  end
+end

--- a/db/migrate/20250829065237_create_product_prices.rb
+++ b/db/migrate/20250829065237_create_product_prices.rb
@@ -1,0 +1,14 @@
+class CreateProductPrices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :product_prices do |t|
+      t.string :stripe_price_id
+      t.string :price_name
+      t.decimal :price
+      t.references :product, null: false, foreign_key: true
+      t.boolean :active
+      t.string :currency
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_20_061034) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_29_065237) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -74,6 +74,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_20_061034) do
     t.index ["product_id"], name: "index_courses_on_product_id"
   end
 
+  create_table "product_prices", force: :cascade do |t|
+    t.string "stripe_price_id"
+    t.string "price_name"
+    t.decimal "price"
+    t.integer "product_id", null: false
+    t.boolean "active"
+    t.string "currency"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_product_prices_on_product_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -81,7 +93,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_20_061034) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "product_creator_id", null: false
+    t.string "stripe_product_id"
     t.index ["product_creator_id"], name: "index_products_on_product_creator_id"
+    t.index ["stripe_product_id"], name: "index_products_on_stripe_product_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -106,5 +120,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_20_061034) do
   add_foreign_key "catalog_product_subscriptions", "products"
   add_foreign_key "catalog_product_subscriptions", "users"
   add_foreign_key "courses", "products"
+  add_foreign_key "product_prices", "products"
   add_foreign_key "products", "users", column: "product_creator_id"
 end

--- a/test/fixtures/product_prices.yml
+++ b/test/fixtures/product_prices.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  stripe_price_id: MyString
+  price_name: MyString
+  price: 9.99
+  product: one
+  active: false
+  currency: MyString
+
+two:
+  stripe_price_id: MyString
+  price_name: MyString
+  price: 9.99
+  product: two
+  active: false
+  currency: MyString

--- a/test/models/product_price_test.rb
+++ b/test/models/product_price_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProductPriceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### What
- Added integration to automatically create a Product and associated Price on Stripe 
  whenever a new Product is created in our system.
- Introduced `ProductPrice` model to store Stripe price details locally.

### Why
- Ensure Stripe stays in sync with our internal product catalog.
- Allow subscriptions and billing to be based on real-time Stripe prices.
- Prevent duplicate manual setup of products/prices in Stripe.

### Related
- Closes [Jira/Trello/GitHub issue link if any]
- Depends on correct Stripe API keys being configured in `.env`.
